### PR TITLE
Change messages to embeds

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,8 @@ import random
 from urllib import request, parse
 import json
 
+import utils as ut
+
 bot = commands.Bot(command_prefix='$', case_insensitive=True)
 start_time = datetime.datetime.now()
 
@@ -24,22 +26,32 @@ async def on_message(message):
     if message.author == bot.user:
         return
 
+    # Secret commands here! They will not show in the help command
+    
     if message.content.startswith('$ping'):
-        await message.channel.send('Hello!')
+        await message.channel.send('Pong and Hello!')
+    
+    if message.content.startswith('$i-read-source-code ' + str(message.author.id)):
+        await message.channel.send(message.author.mention + " reads source code!")
 
 @bot.listen('on_command_error')
-async def on_command_error(ctx, error):
+async def on_command_error(ctx, error):    
     if isinstance(error, commands.CommandNotFound):
         return
     if isinstance(error, commands.MissingRequiredArgument):
-        await ctx.send(str(error))
+        err = str(error)
     if isinstance(error, commands.MissingPermissions):
-        await ctx.send("You do not have the appropriate permissions to run this command.")
+        err = "You do not have the appropriate permissions to run this command."
     if isinstance(error, commands.BotMissingPermissions):
-        await ctx.send("I don't have sufficient permissions!")
+        err = "I don't have sufficient permissions!"
     else:
-        print("error not caught")
-        print(error) 
+        # print("error not caught")
+        # print(error) 
+        raise error
+        # return
+    
+    embed = ut.embeds.ErrorEmbed(ctx, err)
+    await ctx.send(embed=embed)
 
 # Example of a command
 @bot.command(name='command_name', description="Description for help command")
@@ -47,16 +59,19 @@ async def command(ctx, other_arguments_here):
     pass # Do stuff here
 
 @bot.command(name='uptime', description="Get the time the bot has been online")
-async def command(ctx):
-    await ctx.send(f'Uptime: {datetime.datetime.now() - start_time}')
+async def uptime(ctx):
+    t = datetime.datetime.now() - start_time
+    embed = ut.embeds.SendEmbed(ctx, "Uptime", str(t))
+    await ctx.send(embed=embed)
 
 @bot.command(name='8ball', description="Answers a yes/no question")
-async def command(ctx, question):
+async def ball(ctx, *, question):
     answers = ["Yes", "No", "I don't know", "Maybe", "Yep", "Nope", "Absolutley yes", "Absolutley no"]
-    await ctx.send(random.choice(answers))
+    embed = ut.embeds.SendEmbed(ctx, question, random.choice(answers))
+    await ctx.send(embed=embed)
 
 @bot.command(name='translate', description="Translate some text to another language")
-async def command(ctx, language_from, language_to, *, text):
+async def translate(ctx, language_from, language_to, *, text):
     if language_from not in languages.keys():
         await ctx.send(f"Language {language_from} not found")
     elif language_to not in languages.keys():
@@ -75,6 +90,13 @@ async def command(ctx, language_from, language_to, *, text):
     for sentence in json.loads(resp)[0]:
         translated_text += sentence[0]
     
-    await ctx.send(translated_text)
+    embed = ut.embeds.SendEmbed(ctx, "Translated text", translated_text)
+    await ctx.send(embed=embed)
+
+@bot.command(name="latex", description="Render some LaTeX")
+async def latex(ctx, *, latex):
+    url = "https://latex.codecogs.com/gif.latex?\\bg_white&space;" + parse.quote(latex.replace("(", "\(").replace(")", "\)"))
+    embed = ut.embeds.SendEmbed(ctx, "Rendered LaTeX", latex, image=url)
+    await ctx.send(embed=embed)
 
 bot.run(os.environ['BOT_TOKEN'])

--- a/main.py
+++ b/main.py
@@ -9,6 +9,8 @@ import json
 import utils as ut
 
 bot = commands.Bot(command_prefix='$', case_insensitive=True)
+bot.remove_command('help')
+
 start_time = datetime.datetime.now()
 
 with open("./assets/languages.json", "r") as f:
@@ -58,19 +60,19 @@ async def on_command_error(ctx, error):
 async def command(ctx, other_arguments_here):
     pass # Do stuff here
 
-@bot.command(name='uptime', description="Get the time the bot has been online")
+@bot.command(name='uptime', description="Get the time the bot has been online", usage="uptime")
 async def uptime(ctx):
     t = datetime.datetime.now() - start_time
     embed = ut.embeds.SendEmbed(ctx, "Uptime", str(t))
     await ctx.send(embed=embed)
 
-@bot.command(name='8ball', description="Answers a yes/no question")
+@bot.command(name='8ball', description="Answers a yes/no question", usage="8ball <question>")
 async def ball(ctx, *, question):
     answers = ["Yes", "No", "I don't know", "Maybe", "Yep", "Nope", "Absolutley yes", "Absolutley no"]
     embed = ut.embeds.SendEmbed(ctx, question, random.choice(answers))
     await ctx.send(embed=embed)
 
-@bot.command(name='translate', description="Translate some text to another language")
+@bot.command(name='translate', description="Translate some text to another language", usage="translate <language_from> <language_to> <text>")
 async def translate(ctx, language_from, language_to, *, text):
     if language_from not in languages.keys():
         await ctx.send(f"Language {language_from} not found")
@@ -93,10 +95,27 @@ async def translate(ctx, language_from, language_to, *, text):
     embed = ut.embeds.SendEmbed(ctx, "Translated text", translated_text)
     await ctx.send(embed=embed)
 
-@bot.command(name="latex", description="Render some LaTeX")
+@bot.command(name="latex", description="Render some LaTeX", usage="latex <latex_code>")
 async def latex(ctx, *, latex):
     url = "https://latex.codecogs.com/gif.latex?\\bg_white&space;" + parse.quote(latex.replace("(", "\(").replace(")", "\)"))
     embed = ut.embeds.SendEmbed(ctx, "Rendered LaTeX", latex, image=url)
+    await ctx.send(embed=embed)
+
+@bot.command(name="help", description="Get help on commands", usage="help [command]")
+async def help(ctx, command=None):
+    if not command:
+        embed = ut.embeds.HelpEmbed(ctx, bot.commands)
+    else:
+        for c in bot.commands:
+            if c.name == command:
+                command = c
+        if type(command) == str:
+            embed = ut.embeds.ErrorEmbed(ctx, "Command {} not found".format(command))
+            ctx.send(embed=embed)
+            return
+                
+        embed = ut.embeds.CommandHelpEmbed(ctx, command)
+    
     await ctx.send(embed=embed)
 
 bot.run(os.environ['BOT_TOKEN'])

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+from . import embeds

--- a/utils/embeds.py
+++ b/utils/embeds.py
@@ -1,0 +1,14 @@
+import discord
+
+class SendEmbed(discord.Embed):
+    def __init__(self, ctx, title, description, color=0x253439, thumbnail=None, image=None):
+        super().__init__(title=title, description=description, color=color)
+        self.set_footer(text="Requested by " + ctx.author.name, icon_url=ctx.author.avatar_url)
+        if thumbnail:
+            self.set_thumbnail(url=thumbnail)
+        if image:
+            self.set_image(url=image)
+
+class ErrorEmbed(SendEmbed):
+    def __init__(self, ctx, error):
+        super().__init__(ctx, title="Error", description=error, color=discord.Color.red())

--- a/utils/embeds.py
+++ b/utils/embeds.py
@@ -12,3 +12,15 @@ class SendEmbed(discord.Embed):
 class ErrorEmbed(SendEmbed):
     def __init__(self, ctx, error):
         super().__init__(ctx, title="Error", description=error, color=discord.Color.red())
+
+class HelpEmbed(SendEmbed):
+    def __init__(self, ctx, commands):
+        super().__init__(ctx, title="Help", description="Here's a list of commands you can use. Use `{}help [command]` to get more info on a command.".format(ctx.prefix))
+        
+        for command in commands:
+            self.add_field(name=command.name, value=command.description)
+
+class CommandHelpEmbed(SendEmbed):
+    def __init__(self, ctx, command):
+        super().__init__(ctx, title="Help", description=f"Here's some info on the command `{command}`.")    
+        self.add_field(name="Usage", value=f"```{ctx.prefix + command.usage}```")    

--- a/utils/embeds.py
+++ b/utils/embeds.py
@@ -18,9 +18,21 @@ class HelpEmbed(SendEmbed):
         super().__init__(ctx, title="Help", description="Here's a list of commands you can use. Use `{}help [command]` to get more info on a command.".format(ctx.prefix))
         
         for command in commands:
-            self.add_field(name=command.name, value=command.description)
+            if command.description:
+                desc = command.description 
+            else: 
+                desc = "No description available"
+            
+            self.add_field(name=command.name, value=desc)
 
 class CommandHelpEmbed(SendEmbed):
     def __init__(self, ctx, command):
-        super().__init__(ctx, title="Help", description=f"Here's some info on the command `{command}`.")    
-        self.add_field(name="Usage", value=f"```{ctx.prefix + command.usage}```")    
+        if command.description:
+            desc = command.description 
+        else: 
+            desc = "No description available"
+        
+        super().__init__(ctx, title=f"Help on `{command}`", description=desc)    
+        
+        if command.usage:
+            self.add_field(name="Usage", value=f"```{ctx.prefix + command.usage}```")    


### PR DESCRIPTION
Created a local library "utils", changed the messages to embeds, and add 1 new command. Also, I changed the help command to use embeds, but every time a new command is created, a `usage` and `description` should be specified to display best in the help command.